### PR TITLE
test: add comprehensive integration tests for Hero and Agent features

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,13 @@
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>
 		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-webflux</artifactId>
+			<scope>test</scope> <!-- Depende de testes -->
+		</dependency>
+
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>

--- a/src/main/java/com/github/lucasbandeira/msmarvel/resources/HeroController.java
+++ b/src/main/java/com/github/lucasbandeira/msmarvel/resources/HeroController.java
@@ -45,7 +45,6 @@ public class HeroController implements BuildLocationUri {
     @PostMapping
     public ResponseEntity<Void>saveHero( @RequestBody @Valid HeroRequestDTO heroRequestDto ){
         Hero hero = Hero.fromDTO(heroRequestDto);
-        System.out.println(hero.toString());
         heroService.saveHero(hero);
         return ResponseEntity.created(generateURI(hero.getId())).build();
     }
@@ -57,7 +56,7 @@ public class HeroController implements BuildLocationUri {
     }
 
     @PutMapping("/{heroCode}")
-    public ResponseEntity<Void>UpdateHeroById(@PathVariable String heroCode, @RequestBody HeroRequestDTO heroRequestDto){
+    public ResponseEntity<Void>UpdateHeroById(@PathVariable String heroCode, @RequestBody @Valid HeroRequestDTO heroRequestDto){
         heroService.updateHero(heroCode, heroRequestDto);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }

--- a/src/main/java/com/github/lucasbandeira/msmarvel/resources/HeroService.java
+++ b/src/main/java/com/github/lucasbandeira/msmarvel/resources/HeroService.java
@@ -33,7 +33,7 @@ public class HeroService {
     public Optional<Hero> updateHero(String heroCode, HeroRequestDTO dto) {
         Optional<Hero> heroOptional = heroRepository.findByHeroCode(heroCode);
         if (!heroOptional.isPresent()){
-            throw new RuntimeException();
+            throw new HeroNotFoundException("The hero you requested was not found");
         }
 
         return heroOptional.map(existingHero -> {
@@ -41,6 +41,7 @@ public class HeroService {
             existingHero.setSkills(dto.skills());
             existingHero.setAge(dto.age());
             existingHero.setCharacteristics(dto.characteristics());
+            validator.validateHero(existingHero);
             return heroRepository.save(existingHero);
         });
     }

--- a/src/test/java/com/github/lucasbandeira/msmarvel/common/HeroConstants.java
+++ b/src/test/java/com/github/lucasbandeira/msmarvel/common/HeroConstants.java
@@ -20,6 +20,17 @@ public class HeroConstants {
         );
     }
 
+    public static Hero createInvalidHero(){
+        return new Hero(
+                "Marvel-001",
+                "Punisher",
+                List.of("Expert marksmanship", "Hand-to-hand combat"),
+                38,
+                List.of("Vengeful", "Relentless")
+        );
+    }
+
+
 
     public static HeroResponseDTO createHeroResponseDTO(){
         return new HeroResponseDTO(
@@ -41,9 +52,19 @@ public class HeroConstants {
         );
     }
 
+    public static HeroRequestDTO createInvalidHeroRequestDTO(){
+        return new HeroRequestDTO(
+                "",
+                " ",
+                List.of("fly"),
+                null,
+                List.of()
+        );
+    }
+
     public static Agent createAgent(){
         return new Agent(
-                UUID.randomUUID(),
+                null,
                 "AGENT-001",
                 "Nick Fury",
                 true

--- a/src/test/java/com/github/lucasbandeira/msmarvel/domain/AgentRepositoryTest.java
+++ b/src/test/java/com/github/lucasbandeira/msmarvel/domain/AgentRepositoryTest.java
@@ -1,0 +1,52 @@
+package com.github.lucasbandeira.msmarvel.domain;
+
+import static com.github.lucasbandeira.msmarvel.common.HeroConstants.createAgent;
+import static org.assertj.core.api.Assertions.assertThat;
+import com.github.lucasbandeira.msmarvel.infra.repository.AgentRepository;
+import com.github.lucasbandeira.msmarvel.model.Agent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.util.Optional;
+
+@DataJpaTest
+public class AgentRepositoryTest {
+
+    private Agent agent;
+
+    @Autowired
+    private AgentRepository agentRepository;
+
+    @Autowired
+    private TestEntityManager testEntityManager;
+
+    @BeforeEach
+    void setUp(){
+        agent = createAgent();
+    }
+
+    @Test
+    public void findAgent_ByAgentCode_ReturnsAgent(){
+        Agent savedAgent = testEntityManager.persistFlushFind(agent);
+
+        Optional <Agent> agentOptional = agentRepository.findByAgentCode(savedAgent.getAgentCode());
+
+        assertThat(agentOptional).isNotEmpty();
+        assertThat(agentOptional.get()).isEqualTo(savedAgent);
+
+    }
+
+    @Test
+    public void findAgent_ByAgentCode_ReturnsEmpty(){
+        Optional <Agent> agentOptional = agentRepository.findByAgentCode(agent.getAgentCode());
+        assertThat(agentOptional).isEmpty();
+
+    }
+
+
+
+
+}

--- a/src/test/java/com/github/lucasbandeira/msmarvel/domain/HeroRepositoryTest.java
+++ b/src/test/java/com/github/lucasbandeira/msmarvel/domain/HeroRepositoryTest.java
@@ -1,0 +1,87 @@
+package com.github.lucasbandeira.msmarvel.domain;
+
+import static com.github.lucasbandeira.msmarvel.common.HeroConstants.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.lucasbandeira.msmarvel.infra.repository.AgentRepository;
+import com.github.lucasbandeira.msmarvel.infra.repository.HeroRepository;
+import com.github.lucasbandeira.msmarvel.model.Agent;
+import com.github.lucasbandeira.msmarvel.model.Hero;
+import com.github.lucasbandeira.msmarvel.model.dto.HeroRequestDTO;
+import com.github.lucasbandeira.msmarvel.model.dto.HeroResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@DataJpaTest
+public class HeroRepositoryTest {
+
+    private Agent agent;
+    private Hero hero;
+    private HeroRequestDTO heroRequestDTO;
+    private HeroResponseDTO heroResponseDTO;
+    private final UUID heroId = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
+
+
+
+    @Autowired
+    private HeroRepository heroRepository;
+
+    @Autowired
+    private AgentRepository agentRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @BeforeEach
+    void setUp(){
+        agent = createAgent();
+        hero = createHero();
+        heroRequestDTO = createHeroRequestDTO();
+        heroResponseDTO = createHeroResponseDTO();
+    }
+
+    @Test
+    public void findHero_byHeroCode_ReturnsHero(){
+        Hero savedHero = entityManager.persistFlushFind(hero);
+        Optional <Hero> heroOptional = heroRepository.findByHeroCode(hero.getHeroCode());
+
+        assertThat(heroOptional).isNotEmpty();
+        assertThat(heroOptional.get()).isEqualTo(savedHero);
+    }
+
+    @Test
+    public void findHero_byHeroCode_ReturnsEmpty(){
+        Optional <Hero> heroOptional = heroRepository.findByHeroCode(hero.getHeroCode());
+
+        assertThat(heroOptional).isEmpty();
+    }
+
+    @Test
+    public void findHero_ByAgent_ReturnListOfHeroes(){
+        Agent savedAgent = entityManager.persistFlushFind(agent);
+        hero.setAgent(savedAgent);
+        entityManager.persist(hero);
+        List <Hero> heroList = heroRepository.findByAgent_AgentCode(savedAgent.getAgentCode());
+
+        assertThat(heroList).isNotEmpty();
+        assertThat(heroList).hasSize(1);
+        assertThat(heroList.get(0)).isEqualTo(hero);
+    }
+
+    @Test
+    public void findHero_ByAgent_ReturnEmptyList(){
+        List <Hero> heroList = heroRepository.findByAgent_AgentCode(agent.getAgentCode());
+
+        assertThat(heroList).isEmpty();
+    }
+
+}

--- a/src/test/java/com/github/lucasbandeira/msmarvel/web/HeroControllerTest.java
+++ b/src/test/java/com/github/lucasbandeira/msmarvel/web/HeroControllerTest.java
@@ -1,0 +1,327 @@
+package com.github.lucasbandeira.msmarvel.web;
+
+import com.github.lucasbandeira.msmarvel.common.HeroConstants;
+import com.github.lucasbandeira.msmarvel.exception.DuplicateHeroException;
+import com.github.lucasbandeira.msmarvel.exception.HeroNotFoundException;
+import com.github.lucasbandeira.msmarvel.model.Agent;
+import com.github.lucasbandeira.msmarvel.model.Hero;
+import com.github.lucasbandeira.msmarvel.model.dto.HeroRequestDTO;
+import com.github.lucasbandeira.msmarvel.model.dto.HeroResponseDTO;
+import com.github.lucasbandeira.msmarvel.resources.HeroService;
+import com.github.lucasbandeira.msmarvel.validator.HeroValidator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+public class HeroControllerTest {
+
+    private final UUID heroId = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
+    private HeroRequestDTO validHeroRequestDTO;
+    private HeroRequestDTO invalidHeroRequestDTO;
+    private HeroResponseDTO heroResponseDTO;
+    private Hero hero;
+    private Hero invalidHero;
+    private Agent agent;
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @MockitoBean
+    private HeroService heroService;
+
+    @MockitoBean
+    private HeroValidator validator;
+
+
+    @BeforeEach
+    void setUp() {
+        validHeroRequestDTO = HeroConstants.createHeroRequestDTO();
+        invalidHeroRequestDTO = HeroConstants.createInvalidHeroRequestDTO();
+        heroResponseDTO = HeroConstants.createHeroResponseDTO();
+        hero = HeroConstants.createHero();
+        agent = HeroConstants.createAgent();
+        invalidHero = HeroConstants.createInvalidHero();
+    }
+
+    @Test
+    void findAllHeroes_returnsListOfHeroes() {
+        when(heroService.getAllHeroes()).thenReturn(List.of(heroResponseDTO));
+
+        List <HeroResponseDTO> list = webTestClient.get()
+                .uri("/hero")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBodyList(HeroResponseDTO.class)
+                .returnResult()
+                .getResponseBody();
+
+        assertThat(list).isNotEmpty();
+        assertThat(list.get(0)).isEqualTo(heroResponseDTO);
+        assertThat(list).hasSize(1);
+
+        verify(heroService, times(1)).getAllHeroes();
+    }
+
+    @Test
+    void findAllHeroes_returnsEmptyList() {
+        when(heroService.getAllHeroes()).thenReturn(Collections.emptyList());
+
+        webTestClient.get()
+                .uri("/hero")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBodyList(HeroResponseDTO.class).hasSize(0);
+    }
+
+    @Test
+    void listHeroes_ByAgentCode_ReturnsListOfHeroes() {
+        when(heroService.getHeroesByAgent(agent.getAgentCode())).thenReturn(List.of(heroResponseDTO));
+
+        List <HeroResponseDTO> list = webTestClient.get().uri("/hero/by-agent/" + agent.getAgentCode())
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBodyList(HeroResponseDTO.class)
+                .returnResult()
+                .getResponseBody();
+
+        assertThat(list).isNotEmpty();
+        assertThat(list.get(0)).isEqualTo(heroResponseDTO);
+        assertThat(list).hasSize(1);
+
+        verify(heroService, times(1)).getHeroesByAgent(agent.getAgentCode());
+
+    }
+
+    @Test
+    void listHeroes_ByAgentCode_ReturnsEmptyList() {
+        when(heroService.getHeroesByAgent(any(String.class))).thenReturn(Collections.emptyList());
+
+        webTestClient.get().uri("/hero/by-agent/" + agent.getAgentCode())
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus()
+                .isNoContent()
+                .expectBodyList(HeroResponseDTO.class).hasSize(0);
+    }
+
+
+    @Test
+    void createHero_withValidData_ReturnsCreated() {
+
+        when(heroService.saveHero(Hero.fromDTO(validHeroRequestDTO))).thenReturn(hero);
+
+        webTestClient.post().uri("/hero").bodyValue(validHeroRequestDTO)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus()
+                .isCreated()
+                .expectHeader().value("Location", location -> assertThat(location).contains("/hero/"));
+
+        verify(heroService, times(1)).saveHero(any(Hero.class));
+    }
+
+
+    @Test
+    void createHero_withInvalidData_ReturnsDuplicateHeroException() {
+        when(heroService.saveHero(invalidHero)).thenThrow(new DuplicateHeroException("This hero is already registered!"));
+        webTestClient.post()
+                .uri("/hero")
+                .bodyValue(invalidHero)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus()
+                .isEqualTo(HttpStatus.CONFLICT)
+                .expectBody()
+                .consumeWith(response -> {
+                    String responseBody = new String(response.getResponseBody());
+                    assertThat(responseBody).contains("This hero is already registered!");
+                });
+
+    }
+
+    @Test
+    void createHero_withInvalidData_ReturnsUnprocessableEntity() {
+        webTestClient.post()
+                .uri("/hero")
+                .accept(MediaType.APPLICATION_JSON)
+                .bodyValue(invalidHeroRequestDTO)
+                .exchange()
+                .expectStatus()
+                .isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+    }
+
+    @Test
+    void getHero_byId_ReturnsHero() {
+        when(heroService.getById(heroId)).thenReturn(hero);
+
+        HeroResponseDTO sut = webTestClient.get()
+                .uri("/hero/" + heroId)
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBody(HeroResponseDTO.class)
+                .returnResult().getResponseBody();
+
+        assertThat(sut).isNotNull();
+        assertThat(sut.heroCode()).isEqualTo(heroResponseDTO.heroCode());
+        assertThat(sut.age()).isEqualTo(heroResponseDTO.age());
+        assertThat(sut.characteristics()).isEqualTo(heroResponseDTO.characteristics());
+        assertThat(sut.name()).isEqualTo(heroResponseDTO.name());
+        assertThat(sut.skills()).isEqualTo(heroResponseDTO.skills());
+
+        verify(heroService, times(1)).getById(heroId);
+    }
+
+    @Test
+    void getHero_byId_ReturnsHeroNotFoundException() {
+
+        when(heroService.getById(heroId)).thenThrow(new HeroNotFoundException("The hero you requested was not found"));
+
+        webTestClient.get()
+                .uri("/hero/" + heroId)
+                .exchange()
+                .expectStatus()
+                .isNotFound()
+                .expectBody()
+                .consumeWith(response -> {
+                    String responseBody = new String(response.getResponseBody());
+                    assertThat(responseBody).contains("The hero you requested was not found");
+                });
+
+    }
+
+    @Test
+    void updateHero_withValidData_returnsHeroUpdated() {
+        when(heroService.updateHero(hero.getHeroCode(), validHeroRequestDTO)).thenReturn(Optional.of(hero));
+
+        webTestClient.put()
+                .uri("/hero/" + hero.getHeroCode())
+                .bodyValue(validHeroRequestDTO)
+                .exchange()
+                .expectStatus()
+                .isNoContent();
+    }
+
+    @Test
+    void updateHero_withInvalidData_returnsHeroNotFoundException() {
+
+        when(heroService.updateHero(hero.getHeroCode(), validHeroRequestDTO)).thenThrow(new HeroNotFoundException("The hero you requested was not found!"));
+
+        webTestClient.put().uri("/hero/" + hero.getHeroCode())
+                .accept(MediaType.APPLICATION_JSON)
+                .bodyValue(validHeroRequestDTO)
+                .exchange()
+                .expectStatus()
+                .isNotFound()
+                .expectBody()
+                .consumeWith(response -> {
+                    String responseBody = new String(response.getResponseBody());
+                    assertThat(responseBody).contains("The hero you requested was not found!");
+                });
+
+
+    }
+
+    @Test
+    void updateHero_withInvalidData_ReturnsUnprocessableEntity() {
+        webTestClient.put().uri("/hero/"+hero.getHeroCode())
+                .accept(MediaType.APPLICATION_JSON)
+                .bodyValue(invalidHeroRequestDTO)
+                .exchange()
+                .expectStatus()
+                .isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+    }
+
+    @Test
+    void updateHero_withInvalidData_ReturnsDuplicateHeroException(){
+        when(heroService.updateHero(hero.getHeroCode(), validHeroRequestDTO)).thenThrow(new DuplicateHeroException("This hero is already registered!"));
+
+        webTestClient.put().uri("/hero/"+hero.getHeroCode())
+                .accept(MediaType.APPLICATION_JSON)
+                .bodyValue(validHeroRequestDTO)
+                .exchange()
+                .expectStatus()
+                .isEqualTo(HttpStatus.CONFLICT)
+                .expectBody()
+                .consumeWith(response->{
+                    String responseBody = new String(response.getResponseBody());
+                    assertThat(responseBody).contains("This hero is already registered!");
+                });
+
+    }
+
+
+    @Test
+    void deleteHero_byId_ReturnsNoContent() {
+        doNothing().when(heroService).deleteHero(heroId);
+
+        webTestClient.delete()
+                .uri("/hero/" + heroId)
+                .exchange()
+                .expectStatus()
+                .isNoContent();
+    }
+
+    @Test
+    void deleteHero_byId_ReturnsHeroNotFoundException(){
+        doThrow(new HeroNotFoundException("The hero you requested was not found")).when(heroService).deleteHero(heroId);
+
+        webTestClient.delete().uri("/hero/"+heroId)
+                .exchange()
+                .expectStatus()
+                .isNotFound();
+    }
+
+    @Test
+    void getHero_ByHeroCode_ReturnsHero() {
+        when(heroService.getHeroByCode(hero.getHeroCode())).thenReturn(Optional.of(heroResponseDTO));
+
+        HeroResponseDTO sut = webTestClient.get()
+                .uri(uriBuilder -> uriBuilder.path("/hero").queryParam("hero-code", hero.getHeroCode()).build())
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBody(HeroResponseDTO.class)
+                .returnResult()
+                .getResponseBody();
+
+        assertThat(sut).isNotNull();
+    }
+
+    @Test
+    void getHero_ByHeroCode_ReturnsHeroNotFoundException(){
+        when(heroService.getHeroByCode(hero.getHeroCode())).thenThrow(new HeroNotFoundException("The hero you requested was not found"));
+        webTestClient.get().uri(uriBuilder -> uriBuilder.path("/hero").queryParam("hero-code",hero.getHeroCode()).build())
+                .exchange()
+                .expectStatus()
+                .isNotFound()
+                .expectBody()
+                .consumeWith(response->{
+                    String responseBody = new String(response.getResponseBody());
+                    assertThat(responseBody).contains("The hero you requested was not found");
+                });
+    }
+
+}


### PR DESCRIPTION
- Added WebTestClient-based integration tests for HeroController, covering:
  - Retrieval of all heroes and by agent code
  - Hero creation with valid and invalid data
  - Retrieval, update, and deletion by ID and hero code
  - Handling of edge cases such as duplicates and missing heroes

- Added JPA-based integration tests for AgentRepository and HeroRepository:
  - Querying by agentCode and heroCode
  - Validation of repository behavior for both present and absent data

These tests ensure that the main service and data layers handle expected and exceptional flows correctly.