### PR TITLE
Add integration tests for Hero endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,13 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-webflux</artifactId>
-			<scope>test</scope> <!-- Depende de testes -->
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<scope>runtime</scope>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/com/github/lucasbandeira/msmarvel/resources/HeroController.java
+++ b/src/main/java/com/github/lucasbandeira/msmarvel/resources/HeroController.java
@@ -66,8 +66,8 @@ public class HeroController implements BuildLocationUri {
         heroService.deleteHero(id);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
-    @GetMapping(params = "hero-code")
-    public ResponseEntity<HeroResponseDTO> getHeroByCode(@RequestParam("hero-code")String heroCode){
+    @GetMapping("/code/{heroCode}")
+    public ResponseEntity<HeroResponseDTO> getHeroByCode(@PathVariable String heroCode){
         Optional <HeroResponseDTO> hero = heroService.getHeroByCode(heroCode);
         if (hero.isEmpty()) return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
         return ResponseEntity.status(HttpStatus.OK).body(hero.get());

--- a/src/main/java/com/github/lucasbandeira/msmarvel/resources/HeroService.java
+++ b/src/main/java/com/github/lucasbandeira/msmarvel/resources/HeroService.java
@@ -37,11 +37,11 @@ public class HeroService {
         }
 
         return heroOptional.map(existingHero -> {
+            validator.validateHero(existingHero);
             existingHero.setName(dto.name());
             existingHero.setSkills(dto.skills());
             existingHero.setAge(dto.age());
             existingHero.setCharacteristics(dto.characteristics());
-            validator.validateHero(existingHero);
             return heroRepository.save(existingHero);
         });
     }

--- a/src/test/java/com/github/lucasbandeira/msmarvel/HeroIT.java
+++ b/src/test/java/com/github/lucasbandeira/msmarvel/HeroIT.java
@@ -1,0 +1,220 @@
+package com.github.lucasbandeira.msmarvel;
+
+import com.github.lucasbandeira.msmarvel.model.Hero;
+import com.github.lucasbandeira.msmarvel.model.dto.HeroRequestDTO;
+import com.github.lucasbandeira.msmarvel.model.dto.HeroResponseDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static com.github.lucasbandeira.msmarvel.common.HeroConstants.*;
+import static com.github.lucasbandeira.msmarvel.common.HeroConstants.createHeroResponseDTO;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ActiveProfiles("it")
+@Sql(scripts = {"/import_data.sql"},executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+@Sql(scripts = {"/remove_data.sql"},executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class HeroIT {
+
+
+    private HeroRequestDTO validHeroRequestDTO;
+    private HeroRequestDTO invalidHeroRequestDTO;
+    private HeroResponseDTO heroResponseDTO;
+    private Hero hero;
+
+
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @BeforeEach
+    void setUp(){
+        hero = createHero();
+        validHeroRequestDTO = createHeroRequestDTO();
+        heroResponseDTO = createHeroResponseDTO();
+        invalidHeroRequestDTO = createInvalidHeroRequestDTO();
+    }
+
+
+    @Test
+    void listAllHeroes_ReturnsListOfHeroes(){
+        List <HeroResponseDTO> list = webTestClient
+                .get()
+                .uri("/hero")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBodyList(HeroResponseDTO.class).hasSize(3)
+                .returnResult().getResponseBody();
+
+        assertThat(list).isNotEmpty();
+
+    }
+
+
+    @Test
+    void listHeroesByAgentId_ReturnsHeroesList(){
+        List <HeroResponseDTO> list = webTestClient.get()
+                .uri("/hero/by-agent/{agentCode}","Shield-001" )
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBodyList(HeroResponseDTO.class)
+                .returnResult().getResponseBody();
+
+        assertThat(list).isNotEmpty();
+    }
+    @Test
+    void listHeroesByAgentId_ReturnsEmptyList(){
+        webTestClient.get()
+                .uri("/hero/by-agent/{agentCode}","Shield-002")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus()
+                .isNoContent();
+    }
+
+
+    @Test
+    void createHero_ReturnsCreated(){
+        webTestClient.post()
+                .uri("/hero")
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(hero)
+                .exchange()
+                .expectStatus()
+                .isCreated()
+                .expectHeader().value("location",location -> assertThat(location).contains("/hero/"));
+    }
+
+
+    @Test
+    void createHero_ReturnsUnprocessableEntity() {
+        webTestClient.post()
+                .uri("/hero")
+                .accept(MediaType.APPLICATION_JSON)
+                .bodyValue(invalidHeroRequestDTO)
+                .exchange()
+                .expectStatus()
+                .isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+    }
+
+    @Test
+    void getHeroById_ReturnsHero(){
+        HeroResponseDTO sut = webTestClient.get()
+                .uri("/hero/{id}", "187bc50e-b503-4034-9ba1-b1dfd2da3b25")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBody(HeroResponseDTO.class)
+                .returnResult().getResponseBody();
+
+        assertThat(sut.heroCode()).isNotNull();
+
+    }
+
+    @Test
+    void getHeroById_ReturnsHeroHeroNotFound(){
+        webTestClient.get()
+                .uri("/hero/{id}",UUID.randomUUID())
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus()
+                .isNotFound();
+    }
+
+
+    @Test
+    void updateHero_returnsHeroUpdated(){
+        webTestClient.put()
+                .uri("/hero/{heroCode}",validHeroRequestDTO.heroCode())
+                .bodyValue(validHeroRequestDTO)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus()
+                .isNoContent();
+
+        webTestClient.get()
+                .uri("/hero/{id}","187bc50e-b503-4034-9ba1-b1dfd2da3b25")
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBody()
+                .jsonPath("$.name").isEqualTo(validHeroRequestDTO.name())
+                .jsonPath("$.skills").isArray()
+                .jsonPath("$.skills[0]").isEqualTo(validHeroRequestDTO.skills().get(0))
+                .jsonPath("$.age").isEqualTo(validHeroRequestDTO.age())
+                .jsonPath("$.characteristics").isArray();
+    }
+
+    @Test
+    void updateHero_ReturnsUnprocessableEntity(){
+        webTestClient.put()
+                .uri("/hero/{heroCode}",invalidHeroRequestDTO.heroCode())
+                .bodyValue(invalidHeroRequestDTO)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus()
+                .isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+    }
+
+    @Test
+    void deleteHero_ReturnsNoContent(){
+        webTestClient.delete()
+                .uri("/hero/{id}","82fde130-62a7-4270-8028-ba7b18022f25")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus()
+                .isNoContent();
+
+        webTestClient.get()
+                .uri("/hero/{id}","82fde130-62a7-4270-8028-ba7b18022f25")
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus()
+                .isNotFound();
+    }
+
+    @Test
+    void deleteHero_ReturnNotFound(){
+        String invalidId = "9a714f75-819a-4cc8-b13b-9469ac7a2c71";
+        webTestClient.delete()
+                .uri("/hero/{id}",invalidId)
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus()
+                .isNotFound();
+    }
+
+    @Test
+    void getByHeroCode_ReturnsHero(){
+        webTestClient
+                .get()
+                .uri("/hero/code/{heroCode}",validHeroRequestDTO.heroCode())
+                .accept(MediaType.APPLICATION_JSON)
+                .exchange()
+                .expectStatus()
+                .isOk()
+                .expectBody(HeroResponseDTO.class)
+                .value(hero ->{
+                   assertThat("Winter Soldier").isEqualTo(hero.name());
+                   assertThat(38).isEqualTo(hero.age());
+                });
+    }
+}

--- a/src/test/java/com/github/lucasbandeira/msmarvel/common/HeroConstants.java
+++ b/src/test/java/com/github/lucasbandeira/msmarvel/common/HeroConstants.java
@@ -36,25 +36,26 @@ public class HeroConstants {
         return new HeroResponseDTO(
                 "Marvel-001",
                 "Punisher",
-                List.of("Expert marksmanship", "Hand-to-hand combat", "Tactical strategy"),
+                List.of("Expert marksmanship", "Hand-to-hand combat","Tactical strategy"),
                 38,
-                List.of("Vengeful", "Relentless", "Strategic")
+                List.of("Vengeful", "Relentless","Strategic")
         );
     }
 
     public static HeroRequestDTO createHeroRequestDTO(){
         return new HeroRequestDTO(
-                "Marvel-003",
-                "Bucky Barnes",
-                List.of("Enhanced strength", "Expert marksman", "Combat skills", "Cybernetic arm"),
-                100,
-                List.of("Loyal", "Haunted", "Resilient")
+                "Marvel-002",
+                "Captain America",
+                List.of("Super soldier strength", "Expert tactician", "Shield mastery", "Enhanced agility"),
+                104,
+                List.of("Honorable", "Leadership", "Selfless")
         );
+
     }
 
     public static HeroRequestDTO createInvalidHeroRequestDTO(){
         return new HeroRequestDTO(
-                "",
+                "Marvel-099",
                 " ",
                 List.of("fly"),
                 null,

--- a/src/test/java/com/github/lucasbandeira/msmarvel/domain/HeroServiceTest.java
+++ b/src/test/java/com/github/lucasbandeira/msmarvel/domain/HeroServiceTest.java
@@ -105,8 +105,8 @@ public class HeroServiceTest {
 
         Optional <Hero> updatedHero = heroService.updateHero(hero.getHeroCode(), heroRequestDTO);
 
-        assertThat(updatedHero.get().getName()).isEqualTo("Bucky Barnes");
-        assertThat(updatedHero.get().getAge()).isEqualTo(100);
+        assertThat(updatedHero.get().getName()).isEqualTo(heroRequestDTO.name());
+        assertThat(updatedHero.get().getAge()).isEqualTo(heroRequestDTO.age());
 
         verify(heroRepository,times(1)).save(hero);
 

--- a/src/test/java/com/github/lucasbandeira/msmarvel/web/HeroControllerTest.java
+++ b/src/test/java/com/github/lucasbandeira/msmarvel/web/HeroControllerTest.java
@@ -45,8 +45,6 @@ public class HeroControllerTest {
     @MockitoBean
     private HeroService heroService;
 
-    @MockitoBean
-    private HeroValidator validator;
 
 
     @BeforeEach
@@ -62,7 +60,6 @@ public class HeroControllerTest {
     @Test
     void findAllHeroes_returnsListOfHeroes() {
         when(heroService.getAllHeroes()).thenReturn(List.of(heroResponseDTO));
-
         List <HeroResponseDTO> list = webTestClient.get()
                 .uri("/hero")
                 .accept(MediaType.APPLICATION_JSON)
@@ -97,7 +94,7 @@ public class HeroControllerTest {
     void listHeroes_ByAgentCode_ReturnsListOfHeroes() {
         when(heroService.getHeroesByAgent(agent.getAgentCode())).thenReturn(List.of(heroResponseDTO));
 
-        List <HeroResponseDTO> list = webTestClient.get().uri("/hero/by-agent/" + agent.getAgentCode())
+        List <HeroResponseDTO> list = webTestClient.get().uri("/hero/by-agent/{agentCode}",agent.getAgentCode())
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus()
@@ -118,7 +115,7 @@ public class HeroControllerTest {
     void listHeroes_ByAgentCode_ReturnsEmptyList() {
         when(heroService.getHeroesByAgent(any(String.class))).thenReturn(Collections.emptyList());
 
-        webTestClient.get().uri("/hero/by-agent/" + agent.getAgentCode())
+        webTestClient.get().uri("/hero/by-agent/{agentCode}",agent.getAgentCode())
                 .accept(MediaType.APPLICATION_JSON)
                 .exchange()
                 .expectStatus()
@@ -177,7 +174,7 @@ public class HeroControllerTest {
         when(heroService.getById(heroId)).thenReturn(hero);
 
         HeroResponseDTO sut = webTestClient.get()
-                .uri("/hero/" + heroId)
+                .uri("/hero/{id}", heroId)
                 .exchange()
                 .expectStatus()
                 .isOk()
@@ -200,7 +197,7 @@ public class HeroControllerTest {
         when(heroService.getById(heroId)).thenThrow(new HeroNotFoundException("The hero you requested was not found"));
 
         webTestClient.get()
-                .uri("/hero/" + heroId)
+                .uri("/hero/{id}", heroId)
                 .exchange()
                 .expectStatus()
                 .isNotFound()
@@ -217,7 +214,7 @@ public class HeroControllerTest {
         when(heroService.updateHero(hero.getHeroCode(), validHeroRequestDTO)).thenReturn(Optional.of(hero));
 
         webTestClient.put()
-                .uri("/hero/" + hero.getHeroCode())
+                .uri("/hero/{heroCode}",hero.getHeroCode())
                 .bodyValue(validHeroRequestDTO)
                 .exchange()
                 .expectStatus()
@@ -229,7 +226,7 @@ public class HeroControllerTest {
 
         when(heroService.updateHero(hero.getHeroCode(), validHeroRequestDTO)).thenThrow(new HeroNotFoundException("The hero you requested was not found!"));
 
-        webTestClient.put().uri("/hero/" + hero.getHeroCode())
+        webTestClient.put().uri("/hero/{heroCode}",hero.getHeroCode())
                 .accept(MediaType.APPLICATION_JSON)
                 .bodyValue(validHeroRequestDTO)
                 .exchange()
@@ -246,7 +243,7 @@ public class HeroControllerTest {
 
     @Test
     void updateHero_withInvalidData_ReturnsUnprocessableEntity() {
-        webTestClient.put().uri("/hero/"+hero.getHeroCode())
+        webTestClient.put().uri("/hero/{heroCode}",hero.getHeroCode())
                 .accept(MediaType.APPLICATION_JSON)
                 .bodyValue(invalidHeroRequestDTO)
                 .exchange()
@@ -258,7 +255,7 @@ public class HeroControllerTest {
     void updateHero_withInvalidData_ReturnsDuplicateHeroException(){
         when(heroService.updateHero(hero.getHeroCode(), validHeroRequestDTO)).thenThrow(new DuplicateHeroException("This hero is already registered!"));
 
-        webTestClient.put().uri("/hero/"+hero.getHeroCode())
+        webTestClient.put().uri("/hero/{heroCode}",hero.getHeroCode())
                 .accept(MediaType.APPLICATION_JSON)
                 .bodyValue(validHeroRequestDTO)
                 .exchange()
@@ -278,7 +275,7 @@ public class HeroControllerTest {
         doNothing().when(heroService).deleteHero(heroId);
 
         webTestClient.delete()
-                .uri("/hero/" + heroId)
+                .uri("/hero/{id}", heroId)
                 .exchange()
                 .expectStatus()
                 .isNoContent();
@@ -288,7 +285,7 @@ public class HeroControllerTest {
     void deleteHero_byId_ReturnsHeroNotFoundException(){
         doThrow(new HeroNotFoundException("The hero you requested was not found")).when(heroService).deleteHero(heroId);
 
-        webTestClient.delete().uri("/hero/"+heroId)
+        webTestClient.delete().uri("/hero/{id}",heroId)
                 .exchange()
                 .expectStatus()
                 .isNotFound();
@@ -299,7 +296,7 @@ public class HeroControllerTest {
         when(heroService.getHeroByCode(hero.getHeroCode())).thenReturn(Optional.of(heroResponseDTO));
 
         HeroResponseDTO sut = webTestClient.get()
-                .uri(uriBuilder -> uriBuilder.path("/hero").queryParam("hero-code", hero.getHeroCode()).build())
+                .uri("/hero/code/{heroCode}",hero.getHeroCode())
                 .exchange()
                 .expectStatus()
                 .isOk()
@@ -313,7 +310,7 @@ public class HeroControllerTest {
     @Test
     void getHero_ByHeroCode_ReturnsHeroNotFoundException(){
         when(heroService.getHeroByCode(hero.getHeroCode())).thenThrow(new HeroNotFoundException("The hero you requested was not found"));
-        webTestClient.get().uri(uriBuilder -> uriBuilder.path("/hero").queryParam("hero-code",hero.getHeroCode()).build())
+        webTestClient.get().uri("/hero/code/{heroCode}",hero.getHeroCode())
                 .exchange()
                 .expectStatus()
                 .isNotFound()

--- a/src/test/resources/application-it.yml
+++ b/src/test/resources/application-it.yml
@@ -1,0 +1,10 @@
+spring:
+  jpa:
+    hibernate:
+      ddl-auto: update
+  datasource:
+    url: ${HOST:jdbc:postgresql://localhost:5432/marvel}
+    username: ${POSTGRES_USER:dev}
+    password: ${POSTGRES_PASSWORD:123456}
+    driver-class-name: org.postgresql.Driver
+

--- a/src/test/resources/import_data.sql
+++ b/src/test/resources/import_data.sql
@@ -1,0 +1,14 @@
+INSERT INTO tb_agent (id, agent_code, name, active) values ('a150b8b6-1be5-456c-9dfc-7327f4400dae','Shield-001','Nick Fury',TRUE);
+
+INSERT INTO tb_hero (id, hero_code, name, skills, age, characteristics, agent_id) VALUES
+  ('187bc50e-b503-4034-9ba1-b1dfd2da3b25', 'Marvel-002', 'Winter Soldier', ARRAY['Expert marksmanship', 'Hand-to-hand combat', 'Tactical strategy'], 38, ARRAY['Vengeful', 'Relentless', 'Strategic'], 'a150b8b6-1be5-456c-9dfc-7327f4400dae');
+
+INSERT INTO tb_hero (id, hero_code, name, skills, age, characteristics, agent_id) VALUES
+  ('82fde130-62a7-4270-8028-ba7b18022f25', 'Marvel-003', 'Winter Soldier', ARRAY['Super strength', 'Cybernetic arm', 'Stealth'], 39, ARRAY['Conflicted', 'Loyal', 'Stoic'], 'a150b8b6-1be5-456c-9dfc-7327f4400dae');
+
+INSERT INTO tb_hero (id, hero_code, name, skills, age, characteristics, agent_id) VALUES
+  ('6ca12da1-b597-4747-9c54-f7c133ade8de', 'Marvel-004', 'Magneto',
+    ARRAY['Magnetism manipulation', 'Genius-level intellect'],
+    60,
+    ARRAY['Militant', 'Powerful', 'Charismatic'],
+    'a150b8b6-1be5-456c-9dfc-7327f4400dae');

--- a/src/test/resources/remove_data.sql
+++ b/src/test/resources/remove_data.sql
@@ -1,0 +1,1 @@
+TRUNCATE TABLE tb_hero, tb_agent CASCADE;


### PR DESCRIPTION
This PR introduces a complete suite of integration tests for the /hero endpoints, including:

- Listing all heroes
- Filtering by agent ID
- Creating a hero (valid and invalid payloads)
- Retrieving a hero by ID and hero code
- Updating a hero with success and validation failure
- Deleting a hero by ID (valid and invalid cases)

The tests ensure proper status codes and response validation, using WebTestClient and SQL scripts for setup/teardown.